### PR TITLE
Demonstrating py2.6 shlex madness

### DIFF
--- a/pymake/_main.py
+++ b/pymake/_main.py
@@ -30,7 +30,7 @@ def main(argv=None):
     if argv is None: # if argv is empty, fetch from the commandline
         argv = sys.argv[1:]
     elif isinstance(argv, basestring): # else if it's a string, parse it
-        argv = shlex.split(argv)
+        argv = shlex.split(argv.encode('ascii'))
 
     # Parse arguments using docopt
     opts = docopt(__doc__, argv=argv, version=__version__)

--- a/pymake/_main.py
+++ b/pymake/_main.py
@@ -10,7 +10,6 @@ Options:
   -n, --just-print       Don't actually run any commands; just print them
                          (dry-run, recon)
   -i, --ignore-errors    Ignore errors from commands.
-Arguments:
   -f FILE, --file FILE
                  Read FILE as a makefile (makefile) [default: Makefile]
 """
@@ -20,16 +19,23 @@ from ._pymake import parse_makefile_aliases, execute_makefile_commands, \
     PymakeKeyError
 from ._version import __version__  # NOQA
 from docopt import docopt
+import shlex
 import sys
 
 
 __all__ = ["main"]
 
 
-def main():
-    opts = docopt(__doc__, version=__version__)
-    # Filename of the makefile
-    fpath = opts['--file']
+def main(argv=None):
+    if argv is None: # if argv is empty, fetch from the commandline
+        argv = sys.argv[1:]
+    elif isinstance(argv, basestring): # else if it's a string, parse it
+        argv = shlex.split(argv)
+
+    # Parse arguments using docopt
+    opts = docopt(__doc__, argv=argv, version=__version__)
+    # Filename of the makefile (default: Makefile of current dir)
+    fpath = opts.get('--file', 'Makefile')
 
     # Parse the makefile, substitute the aliases and extract the commands
     commands, default_alias = parse_makefile_aliases(fpath)

--- a/pymake/_pymake.py
+++ b/pymake/_pymake.py
@@ -49,7 +49,7 @@ def parse_makefile_aliases(filepath):
     # Substitute macros
     macros = dict(RE_MACRO_DEF.findall(ini_str))
     for _ in range(99):  # allow finite amount of nesting
-        for (m, expr) in macros.iteritems():
+        for (m, expr) in macros.items():
             remacros = re.compile(r"\$\(" + m + "\)", flags=re.M)
             ini_str = remacros.sub(expr, ini_str)
         if not RE_MACRO.match(ini_str):

--- a/pymake/_pymake.py
+++ b/pymake/_pymake.py
@@ -46,13 +46,14 @@ def parse_makefile_aliases(filepath):
     with io.open(filepath, mode='r') as fd:
         ini_str = ini_str + RE_MAKE_CMD.sub('\t', fd.read())
 
+    # Substitute macros
     macros = dict(RE_MACRO_DEF.findall(ini_str))
-    # allow finite amount of nesting
-    for _ in range(99):
+    for _ in range(99):  # allow finite amount of nesting
         for (m, expr) in macros.iteritems():
-            ini_str = re.sub(r"\$\(" + m + "\)", expr, ini_str, flags=re.M)
+            remacros = re.compile(r"\$\(" + m + "\)", flags=re.M)
+            ini_str = remacros.sub(expr, ini_str)
         if not RE_MACRO.match(ini_str):
-            # remove macro definitions from rest of parsing
+            # Remove macro definitions from rest of parsing
             ini_str = RE_MACRO_DEF.sub("", ini_str)
             break
     else:

--- a/pymake/tests/tests_main.py
+++ b/pymake/tests/tests_main.py
@@ -63,9 +63,8 @@ def test_main():
     sys.argv = ['', '-s', '-f', fname, 'err']
     try:
         main()
-    except OSError as e:
-        if 'error 2' not in str(e).lower():  # no such file error
-            raise
+    except (OSError, WindowsError) as e:
+        pass  # test passed if file not found
     else:
         raise PymakeTypeError('err')
 

--- a/pymake/tests/tests_main.py
+++ b/pymake/tests/tests_main.py
@@ -21,14 +21,13 @@ def test_main():
     """ Test execution """
 
     fname = os.path.join(os.path.abspath(repeat(os.path.dirname, 3, __file__)),
-                         "examples", "Makefile")
+                         "examples", "Makefile").replace('\\', '/')
     res = _sh(sys.executable, '-c',
               'from pymake import main; import sys; ' +
               'sys.argv = ["", "-f", "' + fname + '"]; main()',
               stderr=subprocess.STDOUT)
 
     # actual test:
-
     assert ("hello world" in res)
 
     # semi-fake test which gets coverage:
@@ -65,7 +64,7 @@ def test_main():
     try:
         main()
     except OSError as e:
-        if 'no such file' not in str(e).lower():
+        if 'error 2' not in str(e).lower():  # no such file error
             raise
     else:
         raise PymakeTypeError('err')

--- a/pymake/tests/tests_main.py
+++ b/pymake/tests/tests_main.py
@@ -63,7 +63,7 @@ def test_main():
     sys.argv = ['', '-s', '-f', fname, 'err']
     try:
         main()
-    except (OSError, WindowsError) as e:
+    except OSError as e:
         pass  # test passed if file not found
     else:
         raise PymakeTypeError('err')


### PR DESCRIPTION
On python 2.6, shlex fails miserably the unit test because it inserts null characters after each character of any command read from the Makefile:

```
>>  assert ("hello world" in u'[\'k\\x00e\\x00y\\x00b\\x00o\\x00a\\x00r\\x00d\\x
00m\\x00a\\x00s\\x00h\\x00i\\x00t\\x00a\\x00l\\x00l\\x00t\\x00o\\x00g\\x00e\\x00
t\\x00h\\x00e\\x00r\\x00t\\x00h\\x00i\\x00s\\x00s\\x00h\\x00o\\x00u\\x00l\\x00d\
\x00n\\x00o\\x00t\\x00r\\x00u\\x00n\\x00o\\x00t\\x00h\\x00e\\x00r\\x00w\\x00i\\x
00s\\x00e\\x00u\\x00n\\x00i\\x00t\\x00t\\x00e\\x00s\\x00t\\x00s\\x00w\\x00i\\x00
l\\x00l\\x00f\\x00a\\x00i\\x00l\']\r\nkeyboardmashitalltogetherthisshouldnotruno
therwiseunittestswillfail\r\nTraceback (most recent call last):\r\n  File "<stri
ng>", line 1, in <module>\r\n  File "pymake\\_main.py", line 56, in main\r\n
ignore_errors=opts[\'--ignore-errors\'])\r\n  File "pymake\\_pymake.py", line 16
7, in execute_makefile_commands\r\n    check_call(parsed_cmd)\r\n  File "c:\\pyt
hon26\\lib\\subprocess.py", line 483, in check_call\r\n    retcode = call(*popen
args, **kwargs)\r\n  File "c:\\python26\\lib\\subprocess.py", line 470, in call\
r\n    return Popen(*popenargs, **kwargs).wait()\r\n  File "c:\\python26\\lib\\s
ubprocess.py", line 623, in __init__\r\n    errread, errwrite)\r\n  File "c:\\py
thon26\\lib\\subprocess.py", line 833, in _execute_child\r\n    startupinfo)\r\n
TypeError: CreateProcess() argument 2 must be string without null bytes or None,
 not str\r\n')
```

If you look carefully, this:

```
'k\\x00e\\x00y\\x00b\\x00o\\x00a\\x00r\\x00d\\x
00m\\x00a\\x00s\\x00h\\x00i\\x00t\\x00a\\x00l\\x00l\\x00t\\x00o\\x00g\\x00e\\x00
t\\x00h\\x00e\\x00r\\x00t\\x00h\\x00i\\x00s\\x00s\\x00h\\x00o\\x00u\\x00l\\x00d\
\x00n\\x00o\\x00t\\x00r\\x00u\\x00n\\x00o\\x00t\\x00h\\x00e\\x00r\\x00w\\x00i\\x
00s\\x00e\\x00u\\x00n\\x00i\\x00t\\x00t\\x00e\\x00s\\x00t\\x00s\\x00w\\x00i\\x00
l\\x00l\\x00f\\x00a\\x00i\\x00l\'
```

Is in fact the same as:

`keyboardmashitalltogetherthisshouldnotruno
therwiseunittestswillfail`

But with null characters between each character.

I tried everything I could, but I could not overcome this issue. It does not happen on newer versions of Python.

See [this issue](https://bugs.python.org/issue1170) for more details. A possible [alternative here](http://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex) (but it does not support comments yet) and also interesting reads [here](https://pythonhosted.org/kitchen/unicode-frustrations.html) and [here](http://lucumr.pocoo.org/2010/12/24/common-mistakes-as-web-developer/).
