### PR TITLE
Fix authorship

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ py-make
 
 |Build-Status| |Coverage-Status| |Branch-Coverage-Status| |Codacy-Grade| |Libraries-Rank|
 
-|DOI-URI| |LICENCE| |OpenHub-Status| |Gift-Casper|
+|DOI-URI| |LICENCE| |OpenHub-Status|
 
 
 Bring basic ``Makefile`` support to any system with Python.
@@ -139,8 +139,8 @@ Authors
 The main developers, ranked by surviving lines of code
 (`git fame -wMC <https://github.com/casperdcl/git-fame>`__), are:
 
-- Casper da Costa-Luis (`casperdcl <https://github.com/casperdcl>`__, ~99.5%, |Gift-Casper|)
-- Stephen Larroque (`lrq3000 <https://github.com/lrq3000>`__, ~0.5%)
+- Stephen Larroque (`lrq3000 <https://github.com/lrq3000>`__, core logic)
+- Casper da Costa-Luis (`casperdcl <https://github.com/casperdcl>`__, modularization & maintenance)
 
 We are grateful for all |GitHub-Contributions|.
 
@@ -170,8 +170,6 @@ We are grateful for all |GitHub-Contributions|.
    :target: https://github.com/tqdm/py-make/graphs/contributors
 .. |GitHub-Updated| image:: https://img.shields.io/github/last-commit/tqdm/py-make/master.svg?logo=github&logoColor=white&label=pushed
    :target: https://github.com/tqdm/py-make/pulse
-.. |Gift-Casper| image:: https://img.shields.io/badge/gift-donate-ff69b4.svg
-   :target: https://caspersci.uk.to/donate.html
 .. |PyPI-Status| image:: https://img.shields.io/pypi/v/py-make.svg
    :target: https://pypi.org/project/py-make
 .. |PyPI-Downloads| image:: https://img.shields.io/pypi/dm/py-make.svg?label=pypi%20downloads&logo=python&logoColor=white

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description='Makefile execution powered by pure Python',
     long_description=README_rst,
     license='MPLv2.0, MIT Licenses',
-    author='Casper da Costa-Luis',
+    author='Stephen Larroque, Casper da Costa-Luis',
     author_email='casper.dcl@physics.org',
     url='https://github.com/tqdm/pymake',
     maintainer='tqdm developers',


### PR DESCRIPTION
This PR fixes the authorship.

Interestingly, that's one of the instances showing the limitations of `git-fame`, since [your first commit](https://github.com/tqdm/py-make/commit/8c6bf0cfa07750d3b1b433cfc04b6a17ab6d110d) credited [my original code](https://github.com/tqdm/tqdm/commit/7405a59ff2f1986922393c2bec77fced9932b28e) as your contribution. No issue with that first commit, but that's why I chose to remove the `git-fame` percentages as they were misleading.

Other (non necessarily exhaustive) commits list of the genesis of `py-make` in chronological order:
* https://github.com/tqdm/tqdm/commit/f54e371a405aaf7a663ad787a8e8d08336603e3f#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7
* https://github.com/tqdm/tqdm/commit/8b89e16b6892ac01bedac89470fe49f7176dfc76#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7
* https://github.com/tqdm/tqdm/commit/5ddf608f61f3b0292b3549613869ad6b931f5ef6#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7
* https://github.com/tqdm/tqdm/commit/bcf3cca298eb06bacace74108d4bc4713b70ab06#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7

BTW could you please give me back admin access to this repo? I would like to (somewhat) maintain it as I am still using it and see some parts that need improvements, and also some standing PRs. Thank you in advance @casperdcl !